### PR TITLE
Fix coding style

### DIFF
--- a/bug.c
+++ b/bug.c
@@ -45,7 +45,7 @@ static int __init slub_bug_init(void)
 	buf = kmalloc(32, GFP_KERNEL);
 	if (!buf) {
 		pr_err("Error, kmalloc failed!\n");
-		return -1;
+		return -ENOMEM;
 	}
 
 	switch (mode) {

--- a/bug.c
+++ b/bug.c
@@ -12,7 +12,7 @@ enum {
 };
 
 static unsigned char *buf;
-static int mode = BUG_OVERFLOW_REDZONE;
+static int mode;
 
 static void _bug_red(void)
 {


### PR DESCRIPTION
1. Kernel coding style won't allow global variable initialization of value 0.
2. Correct the return value with -ENOMEM